### PR TITLE
BannerDoble v2

### DIFF
--- a/bithouse/schemas/bannerDoble.js
+++ b/bithouse/schemas/bannerDoble.js
@@ -19,17 +19,33 @@ export default {
     {
       name: "description",
       type: "string",
-      title: "Description",
+      title: "Image Description",
     },
     {
-      name:"content",
+      name: "content",
       type: "richTextBody",
       title: "Content",
+    },
+    {
+      name: "subtitle",
+      type: "iconTextObject",
+      title: "Subtitle",
     },
     {
       name: "button",
       type: "buttonObject",
       title: "Button",
+    },
+    {
+      name: "buttonType",
+      type: "string",
+      title: "Button Type",
+      options: {
+        list: [
+          { title: "Button", value: "button" },
+          { title: "Link", value: "link" },
+        ],
+      },
     },
     {
       name: "colorLeft",


### PR DESCRIPTION
Se agrego al BannerDoble un campo subtitle donde se puede cargar un icono y una descripcion. Tambien se agrego la opcion de elegir el tipo del boton: link o boton.