### PR TITLE
Removes unnecesary field

### DIFF
--- a/bithouse/schemas/articleCard.js
+++ b/bithouse/schemas/articleCard.js
@@ -13,10 +13,5 @@ export default {
       type: "richTextBody",
       title: "Card Content",
     },
-    {
-      name: "link",
-      type: "string",
-      title: "Link Name",
-    },
   ],
 };


### PR DESCRIPTION
Se quito el campo link del objeto card, no es necesario ya que se usa el slug del articulo.